### PR TITLE
[Upload Single PHP] Fix "ftbl0cloud.000webhostapp.com" path default when upload on another host

### DIFF
--- a/upload.php
+++ b/upload.php
@@ -89,7 +89,7 @@
           echo "File ". basename( $_FILES["fileupload"]["name"]).
           " Đã upload thành công.";
 
-          echo "File lưu tại https://ftbl0cloud.000webhostapp.com/" . $target_file;
+          echo "File lưu tại: 𝐘𝐨𝐮𝐫 𝐩𝐫𝐞-𝐝𝐢𝐫𝐞𝐜𝐭𝐨𝐫𝐲" . $target_file;
 
       }
       else


### PR DESCRIPTION
To fix a folder path issue in GitHub, you can follow these steps:


Open the file that contains the folder path you want to fix.
Locate the folder path in the file and make sure it is correct.
If the folder path contains a backslash ("") instead of a forward slash ("/"), replace it with a forward slash.
Make sure the folder path doesn't contain any spaces or unsupported characters.
If the folder is located in a subdirectory, make sure you include the subdirectory name at the beginning of the folder path, separated by a forward slash.
Save the file with the corrected folder path.

By following these steps, you should be able to fix any folder path issues in your GitHub repository.

Backup Ver.1
[bShare-Online-Hosting-main.zip](https://github.com/dapps-sc/bShare-Online-Hosting/files/11283983/bShare-Online-Hosting-main.zip)







