### PR TITLE
[Upload Multi File PHP] Fix "ftbl0cloud.000webhostapp.com" path default when upload on another host and fix code Runtime Error

### DIFF
--- a/upload-multi.php
+++ b/upload-multi.php
@@ -5,38 +5,35 @@ if (($_SERVER['REQUEST_METHOD'] === 'POST') &&
 
     $files = $_FILES['fileupload'];
 
-        $names      = $files['name'];
-        $types      = $files['type'];
-        $tmp_names  = $files['tmp_name'];
-        $errors     = $files['error'];
-        $sizes      = $files['size'];
+    $names      = $files['name'];
+    $types      = $files['type'];
+    $tmp_names  = $files['tmp_name'];
+    $errors     = $files['error'];
+    $sizes      = $files['size'];
 
+    $numitems = count($names);
+    $numfiles = 0;
+    for ($i = 0; $i < $numitems; $i ++) {
+        //Kiểm tra file thứ $i trong mảng file, up thành công không
+        if ($errors[$i] == 0) {
+            $numfiles++;
+            echo "Bạn upload file thứ $numfiles:<br>";
+            echo "Tên file: $names[$i] <br>";
+            echo "Lưu tại: 𝐘𝐨𝐮𝐫 𝐩𝐫𝐞-𝐝𝐢𝐫𝐞𝐜𝐭𝐨𝐫𝐲$names[$i] <br>";
+            echo "Cỡ file: $sizes[$i] <br><hr>";
 
-        $numitems = count($names);
-        $numfiles = 0;
-        for ($i = 0; $i < $numitems; $i ++) {
-            //Kiểm tra file thứ $i trong mảng file, up thành công không
-            if ($errors[$i] == 0)
-            {
-                $numfiles++;
-                echo "Bạn upload file thứ $numfiles:<br>";
-                echo "Tên file: $names[$i] <br>";
-                echo "Lưu tại: $tmp_names[$i] <br>";
-                echo "Cỡ file: $sizes[$i] <br><hr>";
-
-                //Code xử lý di chuyển file đến thư mục cần thiết ở đây (bạn tự thực hiện)
-                //Ví dụ move_uploaded_file($tmp_names[$i], /upload/'.$names[$i]);
-
-            }
+            //Code xử lý di chuyển file đến thư mục cần thiết ở đây (bạn tự thực hiện)
+            //Ví dụ 
+            move_uploaded_file($tmp_names[$i], 'uploads-cdn/'.$names[$i]);
         }
-        echo "Tổng số file upload: " .$numfiles;
+    }
+    echo "Tổng số file upload: " .$numfiles;
 }
 ?>
 
 <form method="post" enctype="multipart/form-data">
     <p>Chọn file để upload:
-      (Cỡ lớn nhất mà PHP đang cấu hình cho phép upload là
-      <?=ini_get('upload_max_filesize')?>)</p>
+      (Cỡ lớn nhất mà PHP đang cấu hình cho phép upload là <?=ini_get('upload_max_filesize')?>)</p>
 
     <input name="fileupload[]" type="file" multiple="multiple" />
     <input type="submit" value="Đăng ảnh" name="submit">


### PR DESCRIPTION
To fix a folder path issue in GitHub, you can follow these steps:


Open the file that contains the folder path you want to fix.
Locate the folder path in the file and make sure it is correct.
If the folder path contains a backslash ("") instead of a forward slash ("/"), replace it with a forward slash.
Make sure the folder path doesn't contain any spaces or unsupported characters.
If the folder is located in a subdirectory, make sure you include the subdirectory name at the beginning of the folder path, separated by a forward slash.
Save the file with the corrected folder path.

By following these steps, you should be able to fix any folder path issues in your GitHub repository.

Backup Ver.1
[bShare-Online-Hosting-main.zip](https://github.com/dapps-sc/bShare-Online-Hosting/files/11283983/bShare-Online-Hosting-main.zip)







